### PR TITLE
Bug users bookings should not be overwritten by admin

### DIFF
--- a/server/controllers/bookingsController.js
+++ b/server/controllers/bookingsController.js
@@ -50,8 +50,7 @@ const createBooking = (req, res) => {
 
   const bookings = bookingsModel.allBookings();
   bookings.forEach((booking) => {
-    const { email } = user;
-    if (booking.user_email === email && booking.trip_date === trip.trip_date) {
+    if (booking.allocated_seat === body.seat_number) {
       flag = true;
     }
   });
@@ -59,7 +58,7 @@ const createBooking = (req, res) => {
   if (flag === true) {
     return res.status(409).json({
       status: 'unsuccessful',
-      data: { message: 'Booking has already been made' },
+      data: { message: 'This seat is unavailable' },
     });
   }
 


### PR DESCRIPTION
#### What does this PR do?

Fixes booking overwriting bug

#### Description of Task to be completed?

when a user posts a new booking and an admin posts a booking with the same seat number the users must not be overwritten the user booking

#### How should this be manually tested?

checkout branch bg-fix-bookings-overwiting-167823119. Using postman test the following endpoint.

` POST api/v1/bookings `

as a user
``` javascript
{
   trip_id: 1,
   seat_number: "3b"
}
```
as an admin
``` javascript
{
   trip_id: 1,
   seat_number: "3b"
}
```

#### Any background context you want to provide?

Is a blocker for PT story  **#167752879**

#### What are the relevant pivotal tracker stories?



**#167823119**

#### Screenshots (if appropriate)

<img width="660" alt="Screenshot 2019-08-10 at 9 25 25 AM" src="https://user-images.githubusercontent.com/13886438/62819110-d792a300-bb50-11e9-8bc1-4f266ffd7d87.png">

<img width="594" alt="Screenshot 2019-08-10 at 9 25 36 AM" src="https://user-images.githubusercontent.com/13886438/62819109-d6fa0c80-bb50-11e9-9ead-e982b54d94b2.png">




#### Questions:

none


